### PR TITLE
Other faculties fixes

### DIFF
--- a/KITthesis.cls
+++ b/KITthesis.cls
@@ -285,7 +285,7 @@
    {Institut f\"ur Anthropomatik und Robotik (IAR) -\\ Intelligente Prozessautomation und Robotik (IPR)}
    {Institute for Anthropomatics and Robotics (IAR) -\\ Intelligent Process Automation and Robotics Lab (IPR)}
   }
-\newcommand{\myinstitute}[1]{\renewcommand{\theinstitute}{#1}}
+\newcommand{\institute}[1]{\renewcommand{\theinstitute}{#1}}
 
 \newcommand{\theinstitutefaculty}{
   \iflanguage{ngerman}

--- a/KITthesis.cls
+++ b/KITthesis.cls
@@ -287,7 +287,7 @@
   }
 \newcommand{\institute}[1]{\renewcommand{\theinstitute}{#1}}
 
-\newcommand{\theinstitutefaculty}{
+\newcommand{\theinstitutefaculty}{%
   \iflanguage{ngerman}
    {KIT-Fakult\"at f\"ur Informatik}
    {KIT Department of Informatics}
@@ -369,7 +369,8 @@
     \else
       \large
     \fi
-    \iflanguage{ngerman}{An der Fakult\"at f\"ur Informatik}{At the Department of Computer Science}
+    \iflanguage{ngerman}{An der}{At the}
+    \theinstitutefaculty
     \\
     \theinstitute
 


### PR DESCRIPTION
While trying out your template for another faculty (#26) I noticed two small things: 
1. The *.cls defines a `\myinstitute` and the *.tex a `\institute`
2. The faculty on the cover is hardcoded

Here's my attempt at fixing those. I wasn't sure wheather the default should be "Department of Informatics" or "Department of Computer Science". Either way, IMHO it should be consistent.

Cheers,
Max