### PR TITLE
Fixed broken glossary and acronmy entries.

### DIFF
--- a/KITthesis.cls
+++ b/KITthesis.cls
@@ -591,18 +591,15 @@
 
 \newcommand{\includeglossary}{}
 \renewcommand{\includeglossary}{
-    \glsaddall
     \printglossary %\addcontentsline{toc}{chapter}{\listfigurename}
 }
 \newcommand{\includeacronyms}{}
 \renewcommand{\includeacronyms}{
-    \glsaddall
     \printacronyms %\addcontentsline{toc}{chapter}{\listfigurename}
 }
 % TODO: Check this if its needed in the future...
 \newcommand{\includeglossaries}{}
 \renewcommand{\includeglossaries}{
-    \glsaddall
     \printglossaries %\addcontentsline{toc}{chapter}{\listfigurename}
 }
 %%%


### PR DESCRIPTION
Fixed two issues with the glossary and acronym entries :
- Entries were rendered even when they were not used in the document.
- Entries had two references to pages on which they were not present

This was resolved by removing multiple uses of the \glsaddall command in KITthesis.cls.

**Before:**
![image](https://user-images.githubusercontent.com/38691407/108225630-674ce080-713c-11eb-957f-214fabbdfc7d.png)

**After:**
![image](https://user-images.githubusercontent.com/38691407/108224782-8f880f80-713b-11eb-895c-ce75e08281c3.png)
